### PR TITLE
chore: sync podspec version with package.json and dedupe keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "telegram-react-native",
     "tdlib-wrapper",
     "tdlib-react-native",
-    "telegram-integration",
     "async-api",
     "real-time-messaging",
     "secure-messaging",

--- a/react-native-tdlib.podspec
+++ b/react-native-tdlib.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "react-native-tdlib"
-  s.version      = "1.0.0"
+  s.version      = "2.2.0"
   s.summary      = "React Native wrapper for TDLib"
   s.homepage     = "https://github.com/vladlenskiy/react-native-tdlib"
   s.license      = { :type => "MIT" }


### PR DESCRIPTION
## Summary
- Bump `react-native-tdlib.podspec` version from `1.0.0` to `2.2.0` so it matches `package.json`.
- Remove duplicate `telegram-integration` entry in `package.json` keywords.

Pre-submission polish before adding the library to [react-native-community/directory](https://github.com/react-native-community/directory). No runtime behavior change.

## Test plan
- [x] `pod install` in `example/ios` still resolves the local pod.
- [x] `npm publish --dry-run` shows the expected file list.