### PR TITLE
feat(site): move to react-native-tdlib.js.org custom domain

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -17,7 +17,7 @@ via `.github/workflows/site.yml` on every push to `master` that touches
 
 ```bash
 npm install
-npm run dev     # http://localhost:3000/react-native-tdlib/
+npm run dev     # http://localhost:3000
 npm run build   # static export to ./out
 ```
 

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -19,7 +19,7 @@ const description =
   "React Native bindings for Telegram's TDLib. Prebuilt iOS and Android binaries, a single typed API for chats, messages, reactions, files, and real-time updates.";
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://vladlenskiy.github.io/react-native-tdlib/"),
+  metadataBase: new URL("https://react-native-tdlib.js.org/"),
   title: {
     default: title,
     template: "%s · react-native-tdlib",
@@ -47,8 +47,8 @@ export const metadata: Metadata = {
     canonical: "/",
   },
   icons: {
-    icon: "/react-native-tdlib/icon.svg",
-    apple: "/react-native-tdlib/apple-icon",
+    icon: "/icon.svg",
+    apple: "/apple-icon",
   },
   robots: {
     index: true,
@@ -64,7 +64,7 @@ export const metadata: Metadata = {
     title,
     description,
     type: "website",
-    url: "https://vladlenskiy.github.io/react-native-tdlib/",
+    url: "https://react-native-tdlib.js.org/",
     siteName: "react-native-tdlib",
     locale: "en_US",
   },

--- a/site/app/robots.ts
+++ b/site/app/robots.ts
@@ -5,6 +5,6 @@ export const dynamic = "force-static";
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: { userAgent: "*", allow: "/" },
-    sitemap: "https://vladlenskiy.github.io/react-native-tdlib/sitemap.xml",
+    sitemap: "https://react-native-tdlib.js.org/sitemap.xml",
   };
 }

--- a/site/app/sitemap.ts
+++ b/site/app/sitemap.ts
@@ -9,7 +9,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   return [
     {
-      url: "https://vladlenskiy.github.io/react-native-tdlib/",
+      url: "https://react-native-tdlib.js.org/",
       lastModified,
       changeFrequency: "weekly",
       priority: 1,

--- a/site/components/json-ld.tsx
+++ b/site/components/json-ld.tsx
@@ -14,7 +14,7 @@ export function JsonLd() {
     runtimePlatform: ["iOS", "Android", "React Native"],
     codeRepository: siteConfig.repoUrl,
     license: "https://spdx.org/licenses/MIT.html",
-    url: "https://vladlenskiy.github.io/react-native-tdlib/",
+    url: "https://react-native-tdlib.js.org/",
     ...(release ? { version: release.version } : {}),
     keywords: [
       "react-native",

--- a/site/lib/utils.ts
+++ b/site/lib/utils.ts
@@ -5,8 +5,6 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export const basePath = "/react-native-tdlib";
-
 export function asset(path: string): string {
-  return `${basePath}${path.startsWith("/") ? path : `/${path}`}`;
+  return path.startsWith("/") ? path : `/${path}`;
 }

--- a/site/next.config.ts
+++ b/site/next.config.ts
@@ -1,16 +1,12 @@
 import type { NextConfig } from "next";
 import path from "node:path";
 
-const basePath = "/react-native-tdlib";
-
 const devOrigins = process.env.ALLOWED_DEV_ORIGINS?.split(",")
   .map((s) => s.trim())
   .filter(Boolean);
 
 const nextConfig: NextConfig = {
   output: "export",
-  basePath,
-  assetPrefix: `${basePath}/`,
   trailingSlash: true,
   reactStrictMode: true,
   images: { unoptimized: true },

--- a/site/public/CNAME
+++ b/site/public/CNAME
@@ -1,0 +1,1 @@
+react-native-tdlib.js.org


### PR DESCRIPTION
## Summary

Stacks on #78. Swaps the site off the project-page subpath (`vladlenskiy.github.io/react-native-tdlib/`) to a custom domain `react-native-tdlib.js.org`.

## Depends on

- https://github.com/js-org/js.org/pull/11160 — subdomain registration at JS.ORG (approval typically 1-7 days). Merge this only after the js.org PR is merged and DNS has propagated, otherwise the site goes down for a few minutes on the old URL.

## Changes

- `site/public/CNAME` → `react-native-tdlib.js.org`.
- `next.config.ts`: drop `basePath` and `assetPrefix`.
- `lib/utils.ts`: `asset()` becomes a plain path passthrough.
- `layout.tsx`, `sitemap.ts`, `robots.ts`, `components/json-ld.tsx`: all canonical / OG / sitemap / robots URLs now point at `https://react-native-tdlib.js.org/`.
- Icons metadata: `/icon.svg` and `/apple-icon` (no more subpath prefix).
- `site/README.md`: dev URL updated to `http://localhost:3000`.

## Ready-to-merge checklist

- [ ] #78 merged to `master`
- [ ] js.org PR #11160 merged
- [ ] `dig react-native-tdlib.js.org` resolves
- [ ] GitHub Pages settings show the custom domain as verified with HTTPS enforced

After merge:

- Re-verify https://react-native-tdlib.js.org/ loads end-to-end.
- Re-check OG preview in the X Card Validator with the new URL.
- In Google Search Console add the new property and submit the sitemap.