### PR TITLE
fix(site): keep code blocks from triggering horizontal page scroll on mobile

### DIFF
--- a/site/components/site/code-block.tsx
+++ b/site/components/site/code-block.tsx
@@ -38,7 +38,7 @@ export async function CodeBlock({
   return (
     <div
       className={cn(
-        "relative overflow-hidden rounded-lg border border-border bg-[#0d1117]",
+        "relative w-full overflow-hidden rounded-lg border border-border bg-[#0d1117]",
         className,
       )}
     >

--- a/site/components/site/feature-block.tsx
+++ b/site/components/site/feature-block.tsx
@@ -28,7 +28,7 @@ export async function FeatureBlock({
         reverse && "lg:[&>*:first-child]:order-2",
       )}
     >
-      <div>
+      <div className="min-w-0">
         <p className="font-mono text-xs uppercase tracking-widest text-accent">
           {eyebrow}
         </p>
@@ -39,7 +39,7 @@ export async function FeatureBlock({
           {body}
         </div>
       </div>
-      <div>
+      <div className="min-w-0">
         <CodeBlock code={code} lang={codeLang} filename={filename} />
       </div>
     </div>

--- a/site/components/site/quick-start.tsx
+++ b/site/components/site/quick-start.tsx
@@ -40,7 +40,7 @@ export function QuickStart() {
         </div>
 
         <div className="grid gap-4 lg:grid-cols-[0.9fr_1.4fr]">
-          <div className="flex flex-col gap-3">
+          <div className="flex min-w-0 flex-col gap-3">
             <p className="font-mono text-xs uppercase tracking-widest text-muted">
               1. Install
             </p>
@@ -49,7 +49,7 @@ export function QuickStart() {
               RN ≥ 0.60 · iOS ≥ 11 · Android minSdk ≥ 21
             </p>
           </div>
-          <div className="flex flex-col gap-3">
+          <div className="flex min-w-0 flex-col gap-3">
             <p className="font-mono text-xs uppercase tracking-widest text-muted">
               2. Boot and listen
             </p>


### PR DESCRIPTION
## Summary

Long tokens inside the Shiki-rendered \`<pre>\` were pushing grid/flex cells wider than the viewport on narrow screens. Grid items default to \`min-width: auto\` (== min-content), so the pre's intrinsic width won and the whole page scrolled sideways instead of just the code block.

## Changes

- \`min-w-0\` on the grid cells that wrap \`CodeBlock\` in \`FeatureBlock\` and \`QuickStart\` so each cell can shrink below its longest unbreakable line.
- \`w-full\` on \`CodeBlock\` itself so it can't exceed its parent in any future layout.
- \`<pre>\` keeps \`overflow-x-auto\` — code scrolls inside its own container, page does not.

## Test plan

- [ ] Open the site on mobile / narrow viewport (~375 px). No horizontal scroll on the page itself; code blocks that exceed the viewport scroll inside their own container.
- [ ] Desktop layout unchanged — two-column feature blocks and quick-start grid render as before.