### PR TITLE
feat: add deleteMessages API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 Building a Telegram client should not start with an hour-long TDLib compile. This library ships **prebuilt** TDLib binaries for iOS (`xcframework`, device + simulator) and Android (`arm64-v8a`, `armeabi-v7a`, `x86_64`), wraps the whole API in a single RN module, and streams every update to JS through `NativeEventEmitter`.
 
-- 🚀 **51 first-class methods** — auth, chats, messages, reactions, files, options, users.
+- 🚀 **52 first-class methods** — auth, chats, messages, reactions, files, options, users.
 - 🔄 **Real-time updates** — new messages, typing, read receipts, download progress, reactions.
 - 🧩 **Cross-platform parity** — iOS and Android emit the same TDLib JSON shape. Write once.
 - 🟦 **Fully typed** — `.d.ts` covers every method, event and result.
@@ -94,7 +94,7 @@ npx react-native run-ios       # or run-android
 ## Documentation
 
 - **[Getting Started →](./docs/getting-started.md)** — install, auth flow, first chat.
-- **[API Reference →](./docs/api-reference.md)** — all 51 methods, grouped.
+- **[API Reference →](./docs/api-reference.md)** — all 52 methods, grouped.
 - **[Cookbook →](./docs/cookbook.md)** — practical recipes (messages, reactions, files, options, typing).
 - **[Events →](./docs/events.md)** — `tdlib-update` stream, update types cheatsheet.
 - **[Platform Parity →](./docs/platform-parity.md)** — how iOS and Android stay in sync.

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -32,6 +32,7 @@ const mockMethods = {
   getChatMessagePosition: jest.fn(),
   getMessageThread: jest.fn(),
   getMessageThreadHistory: jest.fn(),
+  deleteMessages: jest.fn(),
   addComment: jest.fn(),
   deleteComment: jest.fn(),
   addMessageReaction: jest.fn(),
@@ -84,8 +85,8 @@ describe('react-native-tdlib', () => {
   });
 
   describe('method count', () => {
-    it('exports exactly 51 methods', () => {
-      expect(Object.keys(TdLib)).toHaveLength(51);
+    it('exports exactly 52 methods', () => {
+      expect(Object.keys(TdLib)).toHaveLength(52);
     });
   });
 
@@ -160,6 +161,16 @@ describe('react-native-tdlib', () => {
     it('delegates getChats with limit', () => {
       TdLib.getChats(20);
       expect(mockMethods.getChats).toHaveBeenCalledWith(20);
+    });
+
+    it('delegates deleteMessages with default revoke=true', () => {
+      TdLib.deleteMessages(12345, [111, 222]);
+      expect(mockMethods.deleteMessages).toHaveBeenCalledWith(12345, [111, 222], true);
+    });
+
+    it('delegates deleteMessages with explicit revoke flag', () => {
+      TdLib.deleteMessages(12345, [111], false);
+      expect(mockMethods.deleteMessages).toHaveBeenCalledWith(12345, [111], false);
     });
   });
 });

--- a/android/src/main/java/com/reactnativetdlib/tdlibclient/TdLibModule.java
+++ b/android/src/main/java/com/reactnativetdlib/tdlibclient/TdLibModule.java
@@ -1393,6 +1393,40 @@ public void addComment(
             }
         }
 
+        @ReactMethod
+        public void deleteMessages(double chatId, ReadableArray messageIds, boolean revoke, Promise promise) {
+            try {
+                if (client == null) {
+                    promise.reject("CLIENT_NOT_INITIALIZED", "TDLib client is not initialized");
+                    return;
+                }
+
+                long[] ids = new long[messageIds.size()];
+                for (int i = 0; i < messageIds.size(); i++) {
+                    ids[i] = (long) messageIds.getDouble(i);
+                }
+
+                TdApi.DeleteMessages deleteMessages = new TdApi.DeleteMessages(
+                    (long) chatId,
+                    ids,
+                    revoke
+                );
+
+                client.send(deleteMessages, result -> {
+                    if (result instanceof TdApi.Ok) {
+                        promise.resolve(true);
+                    } else if (result instanceof TdApi.Error) {
+                        TdApi.Error error = (TdApi.Error) result;
+                        promise.reject("DELETE_MESSAGES_ERROR", error.message);
+                    } else {
+                        promise.reject("DELETE_MESSAGES_FAILED", "Unexpected response from TDLib");
+                    }
+                });
+            } catch (Exception e) {
+                promise.reject("DELETE_MESSAGES_ERROR", e.getMessage());
+            }
+        }
+
 
 
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -62,6 +62,7 @@ interface UserDetails {
 | `getChatMessagePosition` | `(chatId, messageId, threadId)` | `Promise<{raw: string, count?: number}>` |
 | `getMessageThread` | `(chatId, messageId)` | `Promise<TdRawResult>` |
 | `getMessageThreadHistory` | `(chatId, threadId, fromMessageId, offset, limit)` | `Promise<TdRawResult>` |
+| `deleteMessages` | `(chatId, messageIds, revoke?)` | `Promise<boolean>` — deletes one or more messages; `revoke` defaults to `true` (delete for everyone when TDLib allows it). |
 
 ## Comments (channel / forum threads)
 

--- a/example/src/MethodsTestExample.tsx
+++ b/example/src/MethodsTestExample.tsx
@@ -74,6 +74,7 @@ const destructiveMethods = [
   'removeMessageReaction',
   'addComment',
   'deleteComment',
+  'deleteMessages',
   'joinChat',
   'leaveChat',
   'verifyPhoneNumber',
@@ -460,6 +461,16 @@ const MethodsTestExample: React.FC = () => {
     await run('deleteComment', () => TdLib.deleteComment(cid, mid));
   }, [appendLog, run, sampleChatId, sampleMessageId]);
 
+  const runDeleteMessages = useCallback(async () => {
+    const cid = Number(sampleChatId);
+    const mid = Number(sampleMessageId);
+    if (!cid || !mid) {
+      appendLog('⚠ set sampleChatId+sampleMessageId first');
+      return;
+    }
+    await run('deleteMessages', () => TdLib.deleteMessages(cid, [mid]));
+  }, [appendLog, run, sampleChatId, sampleMessageId]);
+
   const stats = useMemo(() => {
     const vals = Object.values(results);
     return {
@@ -556,6 +567,7 @@ const MethodsTestExample: React.FC = () => {
         <Button title="removeMessageReaction" onPress={runRemoveReaction} />
         <Button title="addComment (no topic)" onPress={runAddComment} />
         <Button title="deleteComment" onPress={runDeleteComment} />
+        <Button title="deleteMessages" onPress={runDeleteMessages} />
         <Button title="joinChat" onPress={runJoinChat} />
         <Button title="leaveChat" onPress={runLeaveChat} />
       </View>

--- a/example/src/MethodsTestExample.tsx
+++ b/example/src/MethodsTestExample.tsx
@@ -463,12 +463,15 @@ const MethodsTestExample: React.FC = () => {
 
   const runDeleteMessages = useCallback(async () => {
     const cid = Number(sampleChatId);
-    const mid = Number(sampleMessageId);
-    if (!cid || !mid) {
+    const mids = sampleMessageId
+      .split(',')
+      .map(id => Number(id.trim()))
+      .filter(id => Number.isFinite(id) && id > 0);
+    if (!cid || mids.length === 0) {
       appendLog('⚠ set sampleChatId+sampleMessageId first');
       return;
     }
-    await run('deleteMessages', () => TdLib.deleteMessages(cid, [mid]));
+    await run('deleteMessages', () => TdLib.deleteMessages(cid, mids));
   }, [appendLog, run, sampleChatId, sampleMessageId]);
 
   const stats = useMemo(() => {
@@ -543,7 +546,7 @@ const MethodsTestExample: React.FC = () => {
       <TextInput
         value={sampleMessageId}
         onChangeText={setSampleMessageId}
-        placeholder="messageId"
+        placeholder="messageId or id1,id2"
         placeholderTextColor="gray"
         style={styles.input}
       />

--- a/index.d.ts
+++ b/index.d.ts
@@ -156,6 +156,11 @@ declare module "react-native-tdlib" {
     offset: number,
     limit: number,
   ): Promise<TdRawResult>;
+  export function deleteMessages(
+    chatId: number,
+    messageIds: number[],
+    revoke?: boolean,
+  ): Promise<boolean>;
 
   // ==================== Comments ====================
 
@@ -250,6 +255,7 @@ declare module "react-native-tdlib" {
     getChatMessagePosition: typeof getChatMessagePosition;
     getMessageThread: typeof getMessageThread;
     getMessageThreadHistory: typeof getMessageThreadHistory;
+    deleteMessages: typeof deleteMessages;
 
     addComment: typeof addComment;
     deleteComment: typeof deleteComment;

--- a/index.js
+++ b/index.js
@@ -49,6 +49,8 @@ export default {
   getChatMessagePosition: TdLibModule.getChatMessagePosition,
   getMessageThread: TdLibModule.getMessageThread,
   getMessageThreadHistory: TdLibModule.getMessageThreadHistory,
+  deleteMessages: (chatId, messageIds, revoke = true) =>
+    TdLibModule.deleteMessages(chatId, messageIds, revoke),
 
   // Comments
   addComment: TdLibModule.addComment,

--- a/ios/TdLibModule.mm
+++ b/ios/TdLibModule.mm
@@ -947,6 +947,22 @@ RCT_EXPORT_METHOD(deleteComment:(double)chatId
     } reject:reject];
 }
 
+RCT_EXPORT_METHOD(deleteMessages:(double)chatId
+                  messageIds:(NSArray *)messageIds
+                  revoke:(BOOL)revoke
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    NSDictionary *request = @{
+        @"@type": @"deleteMessages",
+        @"chat_id": @((long long)chatId),
+        @"message_ids": messageIds,
+        @"revoke": @(revoke)
+    };
+    [self sendTdLibRequest:request resolve:^(id result) {
+        resolve(@(YES));
+    } reject:reject];
+}
+
 // ==================== Reactions ====================
 
 RCT_EXPORT_METHOD(addMessageReaction:(double)chatId

--- a/site/components/site/features.tsx
+++ b/site/components/site/features.tsx
@@ -133,7 +133,7 @@ export function Features() {
             title="Load, send, react — one-liners on both platforms."
             body={
               <>
-                All 51 methods — chats, messages, reactions, replies, files,
+                All 52 methods — chats, messages, reactions, replies, files,
                 options, users — are wrapped, typed, and tested on iOS and
                 Android. Same signatures, same error codes, same JSON shapes.
               </>
@@ -192,7 +192,7 @@ export function Features() {
             title="The whole TDLib surface is one call away."
             body={
               <>
-                51 methods are wrapped with typed signatures. Everything else —{" "}
+                52 methods are wrapped with typed signatures. Everything else —{" "}
                 <span className="font-mono text-foreground">setChatTitle</span>,{" "}
                 <span className="font-mono text-foreground">searchMessages</span>,{" "}
                 <span className="font-mono text-foreground">setProfilePhoto</span>,

--- a/site/components/site/hero.tsx
+++ b/site/components/site/hero.tsx
@@ -35,7 +35,7 @@ export function Hero() {
               TDLib
             </a>{" "}
             under the hood. Prebuilt binaries for both platforms, a single
-            typed API for all 51 methods, and every Telegram update streaming
+            typed API for all 52 methods, and every Telegram update streaming
             live through <span className="font-mono text-sm">NativeEventEmitter</span>.
           </p>
 


### PR DESCRIPTION
## Summary
- add a first-class `deleteMessages(chatId, messageIds, revoke?)` API on iOS and Android
- wire the method through the JS export, TypeScript declarations, Jest coverage, docs, and the example methods screen
- update the example so `deleteMessages` can accept comma-separated message IDs and exercise the array-based API directly
- update method-count copy from 51 to 52 in the README and site

## Testing
- `npm test -- --runInBand`
- `npx tsc --noEmit -p tsconfig.json` *(fails due a pre-existing root tsconfig issue unrelated to this PR: it includes `example/` and `site/` files while `rootDir` points at `./src`)*

## Device Testing
- [ ] Ran the method in the example app against a live TDLib session on iOS
- [x] Ran the method in the example app against a live TDLib session on Android

Android:
- verified `deleteMessages(chatId, [messageId])`
- verified `deleteMessages(chatId, [messageId1, messageId2, ...])`
- confirmed the target messages were removed as expected