### PR TITLE
feat: add getTextEntities API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 Building a Telegram client should not start with an hour-long TDLib compile. This library ships **prebuilt** TDLib binaries for iOS (`xcframework`, device + simulator) and Android (`arm64-v8a`, `armeabi-v7a`, `x86_64`), wraps the whole API in a single RN module, and streams every update to JS through `NativeEventEmitter`.
 
-- 🚀 **51 first-class methods** — auth, chats, messages, reactions, files, options, users.
+- 🚀 **52 first-class methods** — auth, chats, messages, reactions, files, options, users.
 - 🔄 **Real-time updates** — new messages, typing, read receipts, download progress, reactions.
 - 🧩 **Cross-platform parity** — iOS and Android emit the same TDLib JSON shape. Write once.
 - 🟦 **Fully typed** — `.d.ts` covers every method, event and result.
@@ -94,7 +94,7 @@ npx react-native run-ios       # or run-android
 ## Documentation
 
 - **[Getting Started →](./docs/getting-started.md)** — install, auth flow, first chat.
-- **[API Reference →](./docs/api-reference.md)** — all 51 methods, grouped.
+- **[API Reference →](./docs/api-reference.md)** — all 52 methods, grouped.
 - **[Cookbook →](./docs/cookbook.md)** — practical recipes (messages, reactions, files, options, typing).
 - **[Events →](./docs/events.md)** — `tdlib-update` stream, update types cheatsheet.
 - **[Platform Parity →](./docs/platform-parity.md)** — how iOS and Android stay in sync.

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -4,6 +4,7 @@ const mockMethods = {
   td_json_client_execute: jest.fn(),
   td_json_client_send: jest.fn(),
   td_json_client_receive: jest.fn(),
+  getTextEntities: jest.fn(),
   startTdLib: jest.fn(),
   login: jest.fn(),
   verifyPhoneNumber: jest.fn(),
@@ -84,8 +85,8 @@ describe('react-native-tdlib', () => {
   });
 
   describe('method count', () => {
-    it('exports exactly 51 methods', () => {
-      expect(Object.keys(TdLib)).toHaveLength(51);
+    it('exports exactly 52 methods', () => {
+      expect(Object.keys(TdLib)).toHaveLength(52);
     });
   });
 
@@ -110,6 +111,11 @@ describe('react-native-tdlib', () => {
     it('delegates td_json_client_receive to native module', () => {
       TdLib.td_json_client_receive();
       expect(mockMethods.td_json_client_receive).toHaveBeenCalled();
+    });
+
+    it('delegates getTextEntities to native module', () => {
+      TdLib.getTextEntities('@telegram #test');
+      expect(mockMethods.getTextEntities).toHaveBeenCalledWith('@telegram #test');
     });
   });
 

--- a/android/src/main/java/com/reactnativetdlib/tdlibclient/TdLibModule.java
+++ b/android/src/main/java/com/reactnativetdlib/tdlibclient/TdLibModule.java
@@ -133,6 +133,20 @@ public class TdLibModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void getTextEntities(String text, Promise promise) {
+        try {
+            TdApi.Object response = Client.execute(new TdApi.GetTextEntities(text != null ? text : ""));
+            if (response != null) {
+                promise.resolve(gson.toJson(response));
+            } else {
+                promise.reject("GET_TEXT_ENTITIES_ERROR", "No response from TDLib");
+            }
+        } catch (Exception e) {
+            promise.reject("GET_TEXT_ENTITIES_EXCEPTION", e.getMessage());
+        }
+    }
+
+    @ReactMethod
     public void td_json_client_receive(Promise promise) {
         try {
             if (client == null) {
@@ -1677,6 +1691,11 @@ public void addComment(
         switch (type) {
             case "getAuthorizationState":
                 return new TdApi.GetAuthorizationState();
+
+            case "getTextEntities": {
+                String text = (String) requestMap.get("text");
+                return new TdApi.GetTextEntities(text != null ? text : "");
+            }
 
             case "setAuthenticationPhoneNumber": {
                 String phoneNumber = (String) requestMap.get("phone_number");

--- a/android/src/main/java/com/reactnativetdlib/tdlibclient/TdLibModule.java
+++ b/android/src/main/java/com/reactnativetdlib/tdlibclient/TdLibModule.java
@@ -1692,11 +1692,6 @@ public void addComment(
             case "getAuthorizationState":
                 return new TdApi.GetAuthorizationState();
 
-            case "getTextEntities": {
-                String text = (String) requestMap.get("text");
-                return new TdApi.GetTextEntities(text != null ? text : "");
-            }
-
             case "setAuthenticationPhoneNumber": {
                 String phoneNumber = (String) requestMap.get("phone_number");
                 return new TdApi.SetAuthenticationPhoneNumber(phoneNumber, null);

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -130,6 +130,12 @@ Escape hatch for TDLib functions not yet wrapped with a dedicated method (`regis
 | `td_json_client_send` | `(request)` | **Fire-and-forget.** Response, if any, arrives via `tdlib-update`. |
 | `td_json_client_receive` | `()` | Blocking receive — only usable when the high-level API is **not** running. |
 
+## Text helpers
+
+| Method | Signature | Returns |
+|---|---|---|
+| `getTextEntities` | `(text: string)` | `Promise<string>` — parses Telegram entities like mentions, hashtags, bot commands, and URLs from plain text. |
+
 ## Result types
 
 ```ts

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -178,6 +178,15 @@ const res = await TdLib.td_json_client_execute({
 const entities = JSON.parse(res).entities;
 ```
 
+Or use the dedicated helper:
+
+```ts
+const res = await TdLib.getTextEntities(
+  'Check @telegram and https://telegram.org',
+);
+const entities = JSON.parse(res).entities;
+```
+
 ## Calling anything TDLib supports
 
 If a function isn't yet wrapped with a dedicated method, use `td_json_client_send` — it's fire-and-forget, and the response (or update) arrives via the usual `tdlib-update` stream:

--- a/example/src/MethodsTestExample.tsx
+++ b/example/src/MethodsTestExample.tsx
@@ -32,6 +32,7 @@ interface TestResult {
 
 const safeMethods = [
   'td_json_client_execute',
+  'getTextEntities',
   'getAuthorizationState',
   'getProfile',
   'getOption',
@@ -186,12 +187,15 @@ const MethodsTestExample: React.FC = () => {
       return 'emitted';
     });
 
-    // Base API: execute is always safe (synchronous, no client needed for some reqs)
+    // Base API helper example
     await run('td_json_client_execute', () =>
       TdLib.td_json_client_execute({
         '@type': 'getTextEntities',
         text: '@telegram /test_command https://telegram.org #test',
       }),
+    );
+    await run('getTextEntities', () =>
+      TdLib.getTextEntities('@telegram /test_command https://telegram.org #test'),
     );
 
     // High-level basics

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,7 @@ declare module "react-native-tdlib" {
   export function td_json_client_send(request: Record<string, unknown>): Promise<string>;
   export function td_json_client_execute(request: Record<string, unknown>): Promise<string>;
   export function td_json_client_receive(): Promise<string>;
+  export function getTextEntities(text: string): Promise<string>;
 
   // ==================== Options ====================
 
@@ -222,6 +223,7 @@ declare module "react-native-tdlib" {
     td_json_client_execute: typeof td_json_client_execute;
     td_json_client_send: typeof td_json_client_send;
     td_json_client_receive: typeof td_json_client_receive;
+    getTextEntities: typeof getTextEntities;
 
     startTdLib: typeof startTdLib;
     login: typeof login;

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ export default {
   td_json_client_execute: TdLibModule.td_json_client_execute,
   td_json_client_send: TdLibModule.td_json_client_send,
   td_json_client_receive: TdLibModule.td_json_client_receive,
+  getTextEntities: TdLibModule.getTextEntities,
 
   // Auth
   startTdLib: TdLibModule.startTdLib,

--- a/ios/TdLibModule.mm
+++ b/ios/TdLibModule.mm
@@ -311,12 +311,7 @@ RCT_EXPORT_METHOD(td_json_client_execute:(NSDictionary *)request
 RCT_EXPORT_METHOD(getTextEntities:(NSString *)text
                   resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    void *c = NULL;
     @try {
-        // Use a short-lived client so this pure helper doesn't depend on the
-        // main TDLib session lifecycle managed by startTdLib/destroy.
-        c = td_json_client_create();
-
         NSDictionary *request = @{
             @"@type": @"getTextEntities",
             @"text": text ?: @""
@@ -325,26 +320,19 @@ RCT_EXPORT_METHOD(getTextEntities:(NSString *)text
         NSError *error = nil;
         NSData *requestData = [NSJSONSerialization dataWithJSONObject:request options:0 error:&error];
         if (error) {
-            td_json_client_destroy(c);
             reject(@"JSON_SERIALIZATION_ERROR", error.localizedDescription, nil);
             return;
         }
 
         NSString *requestString = [[NSString alloc] initWithData:requestData encoding:NSUTF8StringEncoding];
-        const char *response = td_json_client_execute(c, [requestString UTF8String]);
-        NSString *responseString = response != NULL ? [NSString stringWithUTF8String:response] : nil;
-        td_json_client_destroy(c);
-        c = NULL;
+        const char *response = td_json_client_execute(NULL, [requestString UTF8String]);
 
-        if (responseString != nil) {
-            resolve(responseString);
+        if (response != NULL) {
+            resolve([NSString stringWithUTF8String:response]);
         } else {
             reject(@"GET_TEXT_ENTITIES_ERROR", @"No response from TDLib", nil);
         }
     } @catch (NSException *exception) {
-        if (c != NULL) {
-            td_json_client_destroy(c);
-        }
         reject(@"GET_TEXT_ENTITIES_EXCEPTION", exception.reason, nil);
     }
 }

--- a/ios/TdLibModule.mm
+++ b/ios/TdLibModule.mm
@@ -308,6 +308,47 @@ RCT_EXPORT_METHOD(td_json_client_execute:(NSDictionary *)request
     }
 }
 
+RCT_EXPORT_METHOD(getTextEntities:(NSString *)text
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    void *c = NULL;
+    @try {
+        // Use a short-lived client so this pure helper doesn't depend on the
+        // main TDLib session lifecycle managed by startTdLib/destroy.
+        c = td_json_client_create();
+
+        NSDictionary *request = @{
+            @"@type": @"getTextEntities",
+            @"text": text ?: @""
+        };
+
+        NSError *error = nil;
+        NSData *requestData = [NSJSONSerialization dataWithJSONObject:request options:0 error:&error];
+        if (error) {
+            td_json_client_destroy(c);
+            reject(@"JSON_SERIALIZATION_ERROR", error.localizedDescription, nil);
+            return;
+        }
+
+        NSString *requestString = [[NSString alloc] initWithData:requestData encoding:NSUTF8StringEncoding];
+        const char *response = td_json_client_execute(c, [requestString UTF8String]);
+        NSString *responseString = response != NULL ? [NSString stringWithUTF8String:response] : nil;
+        td_json_client_destroy(c);
+        c = NULL;
+
+        if (responseString != nil) {
+            resolve(responseString);
+        } else {
+            reject(@"GET_TEXT_ENTITIES_ERROR", @"No response from TDLib", nil);
+        }
+    } @catch (NSException *exception) {
+        if (c != NULL) {
+            td_json_client_destroy(c);
+        }
+        reject(@"GET_TEXT_ENTITIES_EXCEPTION", exception.reason, nil);
+    }
+}
+
 RCT_EXPORT_METHOD(td_json_client_send:(NSDictionary *)request
                   resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {

--- a/site/components/site/features.tsx
+++ b/site/components/site/features.tsx
@@ -133,7 +133,7 @@ export function Features() {
             title="Load, send, react — one-liners on both platforms."
             body={
               <>
-                All 51 methods — chats, messages, reactions, replies, files,
+                All 52 methods — chats, messages, reactions, replies, files,
                 options, users — are wrapped, typed, and tested on iOS and
                 Android. Same signatures, same error codes, same JSON shapes.
               </>
@@ -192,7 +192,7 @@ export function Features() {
             title="The whole TDLib surface is one call away."
             body={
               <>
-                51 methods are wrapped with typed signatures. Everything else —{" "}
+                52 methods are wrapped with typed signatures. Everything else —{" "}
                 <span className="font-mono text-foreground">setChatTitle</span>,{" "}
                 <span className="font-mono text-foreground">searchMessages</span>,{" "}
                 <span className="font-mono text-foreground">setProfilePhoto</span>,

--- a/site/components/site/hero.tsx
+++ b/site/components/site/hero.tsx
@@ -35,7 +35,7 @@ export function Hero() {
               TDLib
             </a>{" "}
             under the hood. Prebuilt binaries for both platforms, a single
-            typed API for all 51 methods, and every Telegram update streaming
+            typed API for all 52 methods, and every Telegram update streaming
             live through <span className="font-mono text-sm">NativeEventEmitter</span>.
           </p>
 


### PR DESCRIPTION
## Summary
- add a first-class `getTextEntities(text)` API on iOS and Android
- wire the helper through the JS export, TypeScript declarations, Jest coverage, docs, and the example methods screen
- update public method-count copy from 51 to 52 in the README and site

## Testing
- `npm test -- --runInBand`

## Device Testing
- [ ] Ran the method in the example app against a live TDLib session on iOS
- [x] Ran the method in the example app against a live TDLib session on Android

Android:
- verified `getTextEntities('@telegram /test_command https://telegram.org #test')`
- confirmed it returns the expected TDLib `textEntities` result
- confirmed the expected entity types and offsets/lengths are present for mention, bot command, URL, and hashtag