### PR TITLE
chore: add AGENTS.md and AI-assisted PR triage

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,5 +28,6 @@
 - [ ] Method count bumped consistently across `README.md` and `site/components/site/`
 - [ ] Destructive methods added to `destructiveMethods` in `example/src/MethodsTestExample.tsx`
 
-<!-- If this PR was written with meaningful AI agent assistance, keep the marker below. See AGENTS.md. -->
-<!-- AI_ASSISTED_PR -->
+## Disclosure
+
+- [ ] This PR was written with meaningful AI agent assistance (see AGENTS.md)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Testing
+
+- [ ] `npm test -- --runInBand` passes
+
+**For PRs that add or modify native methods (`ios/` or `android/`):**
+
+- [ ] Ran the method in `example/` on iOS against a live TDLib session — log attached below
+- [ ] Ran the method in `example/` on Android against a live TDLib session — log attached below
+
+<details>
+<summary>Device logs</summary>
+
+```
+<!-- paste MethodsTestExample output here, iOS and Android -->
+```
+
+</details>
+
+## Checklist for new / changed methods
+
+- [ ] iOS (`ios/TdLibModule.mm`) and Android (`android/.../TdLibModule.java`) implementations are equivalent
+- [ ] `index.js`, `index.d.ts`, `__tests__/index.test.js` updated
+- [ ] `docs/api-reference.md` (and `docs/cookbook.md` if relevant) updated
+- [ ] Method count bumped consistently across `README.md` and `site/components/site/`
+- [ ] Destructive methods added to `destructiveMethods` in `example/src/MethodsTestExample.tsx`
+
+<!-- If this PR was written with meaningful AI agent assistance, keep the marker below. See AGENTS.md. -->
+<!-- AI_ASSISTED_PR -->

--- a/.github/workflows/ai-pr-triage.yml
+++ b/.github/workflows/ai-pr-triage.yml
@@ -1,0 +1,60 @@
+name: "AI-assisted PR triage"
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add or remove "maybe automated" label based on marker
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = 'AI_ASSISTED_PR';
+            const label = 'maybe automated';
+            const { owner, repo } = context.repo;
+            const number = context.payload.pull_request.number;
+            const body = context.payload.pull_request.body || '';
+            const hasMarker = body.includes(marker);
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner, repo, issue_number: number,
+            });
+            const alreadyLabeled = labels.some(l => l.name === label);
+
+            if (hasMarker && !alreadyLabeled) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label });
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues.createLabel({
+                    owner, repo, name: label,
+                    color: 'ededed',
+                    description: 'PR marked as AI-assisted — auto-closes in 3 days without maintainer confirmation.',
+                  });
+                } else {
+                  throw e;
+                }
+              }
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: number, labels: [label],
+              });
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: number,
+                body: [
+                  'Thanks for disclosing AI assistance — this PR is now labeled `maybe automated`.',
+                  '',
+                  'Per [AGENTS.md](../blob/master/AGENTS.md), this PR will be auto-closed in 3 days unless a maintainer confirms ownership and you provide device-test logs from the example app on iOS and Android. Jest output alone is not sufficient — the test suite mocks the native bridge.',
+                ].join('\n'),
+              });
+            } else if (!hasMarker && alreadyLabeled) {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number: number, name: label,
+              });
+            }

--- a/.github/workflows/ai-pr-triage.yml
+++ b/.github/workflows/ai-pr-triage.yml
@@ -16,12 +16,15 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const marker = 'AI_ASSISTED_PR';
+            // Opt-in disclosure marker: a ticked checkbox in the PR body.
+            // Using a checkbox (not an HTML comment) avoids false positives
+            // from contributors who leave the PR template untouched.
+            const markerRe = /- \[x\] This PR was written with meaningful AI agent assistance/i;
             const label = 'maybe automated';
             const { owner, repo } = context.repo;
             const number = context.payload.pull_request.number;
             const body = context.payload.pull_request.body || '';
-            const hasMarker = body.includes(marker);
+            const hasMarker = markerRe.test(body);
 
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner, repo, issue_number: number,

--- a/.github/workflows/ai-pr-triage.yml
+++ b/.github/workflows/ai-pr-triage.yml
@@ -45,12 +45,15 @@ jobs:
               await github.rest.issues.addLabels({
                 owner, repo, issue_number: number, labels: [label],
               });
+              const agentsMdUrl = `${context.serverUrl}/${owner}/${repo}/blob/master/AGENTS.md`;
               await github.rest.issues.createComment({
                 owner, repo, issue_number: number,
                 body: [
                   'Thanks for disclosing AI assistance — this PR is now labeled `maybe automated`.',
                   '',
-                  'Per [AGENTS.md](../blob/master/AGENTS.md), this PR will be auto-closed in 3 days unless a maintainer confirms ownership and you provide device-test logs from the example app on iOS and Android. Jest output alone is not sufficient — the test suite mocks the native bridge.',
+                  `Per [AGENTS.md](${agentsMdUrl}), this PR will be auto-closed in 3 days unless a maintainer confirms ownership and you provide device-test logs from the example app on iOS and Android. Jest output alone is not sufficient — the test suite mocks the native bridge.`,
+                  '',
+                  '_Maintainer: add the `reviewed` label to keep this PR open past the 3-day window._',
                 ].join('\n'),
               });
             } else if (!hasMarker && alreadyLabeled) {

--- a/.github/workflows/device-test-check.yml
+++ b/.github/workflows/device-test-check.yml
@@ -1,0 +1,62 @@
+name: "Device-test claim check"
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  check:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect whether PR touches native bridge
+        id: touches
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const native = files.some(f =>
+              f.filename.startsWith('ios/') ||
+              f.filename.startsWith('android/src/')
+            );
+            core.info(`Files changed: ${files.length}`);
+            core.info(`Touches native bridge: ${native}`);
+            core.setOutput('native', native);
+
+      - name: Verify device-test checkboxes
+        if: steps.touches.outputs.native == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const iosChecked = /- \[x\] Ran the method[^\n]*iOS/i.test(body);
+            const androidChecked = /- \[x\] Ran the method[^\n]*Android/i.test(body);
+
+            if (iosChecked && androidChecked) {
+              core.info('Both device-test checkboxes are checked.');
+              return;
+            }
+
+            const iosStatus = iosChecked ? 'checked' : 'UNCHECKED';
+            const androidStatus = androidChecked ? 'checked' : 'UNCHECKED';
+            core.setFailed([
+              'This PR changes native bridge code (ios/ or android/src/).',
+              '',
+              'Both device-test checkboxes must be checked in the PR description:',
+              `  • iOS:     ${iosStatus}`,
+              `  • Android: ${androidStatus}`,
+              '',
+              'If you genuinely ran the method in the example app against a live',
+              'TDLib session on both platforms, tick the boxes and paste the log',
+              'output below them. See AGENTS.md — the Jest suite cannot verify',
+              'the native bridge, only the JS delegation layer.',
+            ].join('\n'));

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,11 +15,28 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-stale: 30            
-          days-before-close: 7             
+          days-before-stale: 30
+          days-before-close: 7
           stale-issue-message: |
             ⚠️ This issue has been automatically marked as stale due to 30 days of inactivity.
             It will be closed in 7 days if no further comments are made.
             If this is still relevant, feel free to comment or add the `important` label to keep it open.
           exempt-issue-labels: "important,pinned"
-          remove-stale-when-updated: true   
+          remove-stale-when-updated: true
+
+  stale-ai-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          only-pr-labels: "maybe automated"
+          days-before-pr-stale: 3
+          days-before-pr-close: 0
+          stale-pr-message: |
+            This PR is labeled `maybe automated` and has not been confirmed by a maintainer within 3 days. Closing per [AGENTS.md](../blob/master/AGENTS.md).
+
+            To reopen: provide device-test logs from the example app on iOS and Android against a live TDLib session, and request re-review.
+          close-pr-message: "Closed — see AGENTS.md to reopen with device-test evidence."
+          exempt-pr-labels: "reviewed,important"
+          days-before-issue-stale: -1
+          days-before-issue-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,6 +32,12 @@ jobs:
           only-pr-labels: "maybe automated"
           days-before-pr-stale: 3
           days-before-pr-close: 0
+          # Base the 3-day deadline on PR creation, not last activity.
+          # Without this, a rebase push or any comment resets the timer
+          # and the PR never ages into "stale", defeating the policy.
+          # Maintainer override is still the `reviewed` exempt label.
+          ignore-pr-updates: true
+          remove-stale-when-updated: false
           stale-pr-message: |
             This PR is labeled `maybe automated` and has not been confirmed by a maintainer within 3 days. Closing per [AGENTS.md](../blob/master/AGENTS.md).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,15 @@ missing `RCT_EXPORT_METHOD` macro.
 
 **`npm test` passing is not evidence that a new native method works.**
 
-If you add or modify a method that touches `ios/` or `android/`, you
-are expected to run it end-to-end in the example app on both platforms
-against a live TDLib session and include the log output in the PR body.
-See the PR template for the exact checklist.
+If you add or modify a method that touches `ios/` or `android/src/`,
+you are expected to run it end-to-end in the example app on both
+platforms against a live TDLib session and include the log output in
+the PR body. See the PR template for the exact checklist.
+
+A CI check enforces this: PRs touching native bridge code must have
+both device-test checkboxes ticked in the PR description, or the
+`Device-test claim check` job fails. Ticking the boxes without real
+evidence is dishonest and will be caught on review.
 
 ## Project conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,111 @@
+# AI Agent Guide for react-native-tdlib
+
+This document tells AI coding agents what they need to know before
+making changes to this repository. It follows the [agents.md][agents]
+convention.
+
+[agents]: https://agents.md/
+
+## What this project is
+
+`react-native-tdlib` is a React Native bridge for [TDLib][tdlib],
+Telegram's official client library. It ships prebuilt TDLib binaries
+(iOS `xcframework`, Android `.so` for three ABIs) and exposes every
+wrapped method through a single native module.
+
+[tdlib]: https://core.telegram.org/tdlib
+
+Surface you will touch:
+
+- `ios/TdLibModule.mm` — Objective-C++ bridge
+- `android/src/main/java/com/reactnativetdlib/tdlibclient/TdLibModule.java` — Android bridge
+- `index.js` — JS exports
+- `index.d.ts` — TypeScript declarations
+- `__tests__/index.test.js` — Jest delegation tests
+- `docs/api-reference.md`, `docs/cookbook.md` — public documentation
+- `example/src/MethodsTestExample.tsx` — manual device-test harness
+
+## Critical: what the test suite does and does not prove
+
+The Jest suite in `__tests__/` **mocks the entire native module**. It
+verifies that `index.js` delegates to the right native function with
+the right arguments, and nothing else. It does not compile Obj-C++ or
+Java, does not run TDLib, and cannot detect a type mismatch at the
+bridge layer, a wrong `@type` string, a bad `ReadableArray` cast, or a
+missing `RCT_EXPORT_METHOD` macro.
+
+**`npm test` passing is not evidence that a new native method works.**
+
+If you add or modify a method that touches `ios/` or `android/`, you
+are expected to run it end-to-end in the example app on both platforms
+against a live TDLib session and include the log output in the PR body.
+See the PR template for the exact checklist.
+
+## Project conventions
+
+### Cross-platform parity
+
+Every wrapped method exists on both platforms and returns the same
+JSON shape. When you add a method, touch both `ios/TdLibModule.mm` and
+`android/.../TdLibModule.java` in the same PR. Asymmetric PRs are not
+merged.
+
+### JS / TS surface
+
+- Export the method from `index.js` (keep sections ordered the way
+  they already are — auth, chats, messages, reactions, files, etc).
+- Add a typed declaration to `index.d.ts` in the matching section and
+  to the default-export interface at the bottom.
+- Add a Jest delegation test in `__tests__/index.test.js` that asserts
+  the arguments passed to the native mock.
+- Update the exported method count in `__tests__/index.test.js`
+  (`exports exactly N methods`).
+
+### Documentation and copy
+
+When method count changes, update every copy that references it:
+
+- `README.md` — the two places where "N first-class methods" appears.
+- `docs/api-reference.md` — add a table row in the correct section.
+- `site/components/site/hero.tsx` and `site/components/site/features.tsx`
+  — the two references on the landing page.
+
+### Example app
+
+- Add the method to `example/src/MethodsTestExample.tsx` with a button
+  that calls it.
+- If the method is destructive (deletes, leaves, revokes, removes),
+  add its name to the `destructiveMethods` array in the same file.
+
+### Commit messages and PR titles
+
+Conventional Commits in English. Examples:
+
+- `feat: add deleteMessages API`
+- `fix(ios): handle null promise in getChats`
+- `chore(deps): bump jest to 30.3.0`
+
+## Style
+
+- No emojis in source files unless the existing file already uses them.
+- No redundant comments explaining what a line does.
+- Match the error-code pattern of neighboring code: `FEATURE_ERROR`,
+  `FEATURE_FAILED`, `CLIENT_NOT_INITIALIZED`.
+
+## PR description requirement
+
+When opening a pull request, include the following HTML comment at
+the bottom of the PR description:
+
+```
+<!-- AI_ASSISTED_PR -->
+```
+
+This allows the maintainer to identify AI-assisted PRs for triage.
+PRs containing this marker are automatically labeled `maybe automated`
+and will be closed in 3 days unless a human confirms ownership and
+provides device-test evidence (see the PR template).
+
+If you are a human contributor who used an AI agent as a tool but
+reviewed every change yourself and ran the code on a real device,
+include the marker anyway — honesty keeps the signal useful.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,18 +99,19 @@ Conventional Commits in English. Examples:
 
 ## PR description requirement
 
-When opening a pull request, include the following HTML comment at
-the bottom of the PR description:
+The PR template ends with a `## Disclosure` section containing this
+checkbox:
 
 ```
-<!-- AI_ASSISTED_PR -->
+- [ ] This PR was written with meaningful AI agent assistance (see AGENTS.md)
 ```
 
-This allows the maintainer to identify AI-assisted PRs for triage.
-PRs containing this marker are automatically labeled `maybe automated`
-and will be closed in 3 days unless a human confirms ownership and
-provides device-test evidence (see the PR template).
+If an AI agent did meaningful work on the change, tick the box. A
+ticked box labels the PR `maybe automated`, and it will be closed in
+3 days unless a maintainer confirms ownership and you provide
+device-test evidence from the example app on iOS and Android (Jest
+output alone is not sufficient — the suite mocks the native bridge).
 
-If you are a human contributor who used an AI agent as a tool but
-reviewed every change yourself and ran the code on a real device,
-include the marker anyway — honesty keeps the signal useful.
+Leave the box unticked only if the PR is entirely human-authored.
+Ticking the box is opt-in disclosure, not a punishment — it lets the
+maintainer prioritize review and keeps the triage signal honest.


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` at the repo root — project conventions for AI agents, with an explicit disclosure requirement (Vitest-style marker).
- Adds `.github/PULL_REQUEST_TEMPLATE.md` with a checklist that requires device-test logs for PRs that touch `ios/` or `android/`.
- Adds `.github/workflows/ai-pr-triage.yml` — labels marked PRs `maybe automated` and posts a reminder.
- Extends `.github/workflows/stale.yml` with a second job that auto-closes `maybe automated` PRs after 3 days unless a `reviewed` or `important` label is added.

## Why
Jest covers only JS delegation — it mocks the native module entirely. A passing `npm test` tells us nothing about whether a new Obj-C++ or Java bridge method works. Recent PRs added methods with only Jest output as evidence; this gives the maintainer a consistent triage signal.

Policy is explicit (follow the [Vitest AGENTS.md](https://github.com/vitest-dev/vitest/blob/main/AGENTS.md) pattern), not a trap: contributors are asked to honestly disclose AI assistance, and the reward is faster / clearer triage, not an auto-merge.

## Test plan
- [ ] Merge this PR, then open a test PR containing `<!-- AI_ASSISTED_PR -->` in the body — confirm the label is added and the reminder comment posts.
- [ ] Edit the test PR to remove the marker — confirm the label is removed.
- [ ] Let a `maybe automated` PR sit for 3 days without the `reviewed` label — confirm auto-close fires on the next daily cron.