### PR TITLE
security: bump fast-uri, ip-address, postcss to patch Dependabot alerts

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -7661,9 +7661,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
-      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "license": "BSD-3-Clause"
     },

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3711,9 +3711,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz"
-  integrity sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fastq@^1.6.0:
   version "1.18.0"

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -27,6 +27,9 @@
         "@types/react-dom": "^19",
         "tailwindcss": "^4",
         "typescript": "^5"
+      },
+      "overrides": {
+        "postcss": "^8.5.14"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2014,9 +2017,9 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2033,9 +2036,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -2065,9 +2068,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/site/package.json
+++ b/site/package.json
@@ -27,5 +27,8 @@
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "^8.5.14"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3217,13 +3217,10 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-ip-address@^9.0.5:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
-  integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
-  dependencies:
-    jsbn "1.1.0"
-    sprintf-js "^1.1.3"
+ip-address@^10.1.1:
+  version "10.2.0"
+  resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz"
+  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -5062,11 +5059,11 @@ socks-proxy-agent@9.0.0:
     socks "^2.8.3"
 
 socks@^2.8.3:
-  version "2.8.4"
-  resolved "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz"
-  integrity sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==
+  version "2.8.9"
+  resolved "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz"
+  integrity sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==
   dependencies:
-    ip-address "^9.0.5"
+    ip-address "^10.1.1"
     smart-buffer "^4.2.0"
 
 source-map-support@0.5.13:


### PR DESCRIPTION
## Summary

Closes 6 open Dependabot alerts:

| # | CVE | Package | Severity | Bump |
|---|---|---|---|---|
| 137 | CVE-2026-6321 | fast-uri | high | 3.0.3 → 3.1.2 (`example/package-lock.json`) |
| 138 | CVE-2026-6321 | fast-uri | high | 3.0.3 → 3.1.2 (`example/yarn.lock`) |
| 139 | CVE-2026-6322 | fast-uri | high | covered by same bump |
| 140 | CVE-2026-6322 | fast-uri | high | covered by same bump |
| 133 | CVE-2026-42338 | ip-address | medium | 9.0.5 → 10.2.0 (via socks 2.8.4 → 2.8.9 in `yarn.lock`) |
| 132 | CVE-2026-41305 | postcss | medium | 8.4.31 (nested in next) and 8.5.10 → 8.5.14 in `site/package-lock.json` via npm `overrides` |

## Notes

- **fast-uri** lives only in `example/` (demo app, scope=development) — not shipped to npm consumers of `react-native-tdlib`.
- **ip-address** is bumped transitively by upgrading `socks` within its existing `^2.8.3` semver range; no breaking API change at our usage level.
- **postcss** uses npm `overrides` in `site/package.json` because `next@16.2.4` exact-pins postcss `8.4.31`. Override forces the deduped fix without bumping next itself.

## Test plan

- [ ] CI green on `security/dependabot-bumps`
- [ ] After merge: confirm Dependabot alerts #132, #133, #137-140 transition to `fixed`
- [ ] `cd example && yarn install --frozen-lockfile` succeeds
- [ ] `cd example && npm ci` succeeds
- [ ] `cd site && npm ci` succeeds and `npm run build` works