### PR TITLE
fix(android): return low-level TDLib responses instead of only logging updates

### DIFF
--- a/android/src/main/java/com/reactnativetdlib/tdlibclient/TdLibModule.java
+++ b/android/src/main/java/com/reactnativetdlib/tdlibclient/TdLibModule.java
@@ -116,12 +116,16 @@ public class TdLibModule extends ReactContextBaseJavaModule {
             Map<String, Object> requestMap = request.toHashMap();
             TdApi.Function function = convertMapToFunction(requestMap);
 
-            client.send(function, new Client.ResultHandler() {
-                @Override
-                public void onResult(TdApi.Object object) {
-                    lowLevelResponses.offer(object);
-                }
-            });
+            if (highLevelStarted) {
+                client.send(function, null, null);
+            } else {
+                client.send(function, new Client.ResultHandler() {
+                    @Override
+                    public void onResult(TdApi.Object object) {
+                        lowLevelResponses.offer(object);
+                    }
+                });
+            }
             promise.resolve("Request sent successfully");
         } catch (Exception e) {
             promise.reject("SEND_EXCEPTION", e.getMessage());
@@ -191,7 +195,7 @@ public class TdLibModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void startTdLib(ReadableMap parameters, Promise promise) {
         try {
-            if (highLevelStarted) {
+            if (client != null) {
                 promise.resolve("TDLib already started");
                 return;
             }

--- a/android/src/main/java/com/reactnativetdlib/tdlibclient/TdLibModule.java
+++ b/android/src/main/java/com/reactnativetdlib/tdlibclient/TdLibModule.java
@@ -25,10 +25,10 @@ import com.google.gson.Gson;
 
 import org.drinkless.tdlib.Client;
 import org.drinkless.tdlib.TdApi;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.Map;
 import java.util.HashMap;
 import org.json.JSONObject;
@@ -52,7 +52,9 @@ import androidx.annotation.NonNull;
 
 public class TdLibModule extends ReactContextBaseJavaModule {
     private static final String TAG = "TdLibModule";
-    private Client client;
+    private volatile Client client;
+    private volatile boolean highLevelStarted = false;
+    private final BlockingQueue<TdApi.Object> lowLevelResponses = new LinkedBlockingQueue<>();
     private final Gson gson = TdLibJson.GSON;
 
     private final ReactApplicationContext reactContext;
@@ -70,17 +72,8 @@ public class TdLibModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void td_json_client_create(Promise promise) {
         try {
-            if (client == null) {
-                client = Client.create(
-                        new Client.ResultHandler() {
-                            @Override
-                            public void onResult(TdApi.Object object) {
-                                Log.d(TAG, "Global Update: " + gson.toJson(object));
-                            }
-                        },
-                        null,
-                        null
-                );
+            boolean created = ensureClient();
+            if (created) {
                 promise.resolve("TDLib client created");
             } else {
                 promise.resolve("TDLib client already exists");
@@ -123,9 +116,12 @@ public class TdLibModule extends ReactContextBaseJavaModule {
             Map<String, Object> requestMap = request.toHashMap();
             TdApi.Function function = convertMapToFunction(requestMap);
 
-            // Fire-and-forget — matches iOS and C API semantics.
-            // Responses surface via the global update handler (tdlib-update event).
-            client.send(function, null, null);
+            client.send(function, new Client.ResultHandler() {
+                @Override
+                public void onResult(TdApi.Object object) {
+                    lowLevelResponses.offer(object);
+                }
+            });
             promise.resolve("Request sent successfully");
         } catch (Exception e) {
             promise.reject("SEND_EXCEPTION", e.getMessage());
@@ -154,20 +150,18 @@ public class TdLibModule extends ReactContextBaseJavaModule {
                 return;
             }
 
-            CountDownLatch latch = new CountDownLatch(1);
-            AtomicReference<TdApi.Object> responseRef = new AtomicReference<>();
+            if (highLevelStarted) {
+                promise.reject(
+                    "RECEIVE_LOOP_ACTIVE",
+                    "Cannot use td_json_client_receive while the high-level API (startTdLib) is active. " +
+                        "Use NativeEventEmitter to listen for tdlib-update events instead."
+                );
+                return;
+            }
 
-            client.send(null, new Client.ResultHandler() {
-                @Override
-                public void onResult(TdApi.Object object) {
-                    responseRef.set(object);
-                    latch.countDown();
-                }
-            });
-
-            boolean awaitSuccess = latch.await(10, TimeUnit.SECONDS);
-            if (awaitSuccess && responseRef.get() != null) {
-                promise.resolve(gson.toJson(responseRef.get()));
+            TdApi.Object response = lowLevelResponses.poll(10, TimeUnit.SECONDS);
+            if (response != null) {
+                promise.resolve(gson.toJson(response));
             } else {
                 promise.reject("RECEIVE_ERROR", "No response from TDLib");
             }
@@ -197,57 +191,13 @@ public class TdLibModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void startTdLib(ReadableMap parameters, Promise promise) {
         try {
-            if (client != null) {
+            if (highLevelStarted) {
                 promise.resolve("TDLib already started");
                 return;
             }
 
-            client = Client.create(
-                new Client.ResultHandler() {
-                    @Override
-                    public void onResult(TdApi.Object object) {
-                        WritableMap map = Arguments.createMap();
-                        String json = gson.toJson(object);
-
-                        // Match iOS: TDLib-style camelCase type and raw=direct TDLib JSON
-                        String simple = object.getClass().getSimpleName();
-                        String type = simple.isEmpty()
-                            ? simple
-                            : Character.toLowerCase(simple.charAt(0)) + simple.substring(1);
-
-                        map.putString("type", type);
-                        map.putString("raw", json);
-
-                        getReactApplicationContext()
-                            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                            .emit("tdlib-update", map);
-
-                        // Tear down the client after TDLib fully closes so the next
-                        // startTdLib creates a fresh one (logout/destroy path).
-                        if (object instanceof TdApi.UpdateAuthorizationState) {
-                            TdApi.AuthorizationState st =
-                                ((TdApi.UpdateAuthorizationState) object).authorizationState;
-                            if (st instanceof TdApi.AuthorizationStateClosed) {
-                                client = null;
-                            }
-                        }
-
-                        if (object instanceof TdApi.UpdateMessageInteractionInfo) {
-                            TdApi.UpdateMessageInteractionInfo interaction =
-                                    (TdApi.UpdateMessageInteractionInfo) object;
-                            Log.d("TDLib", "Interaction update for msg " + interaction.messageId);
-                        }
-
-                        if (object instanceof TdApi.UpdateMessageReactions) {
-                            TdApi.UpdateMessageReactions reaction =
-                                    (TdApi.UpdateMessageReactions) object;
-                            Log.d("TDLib", "Reactions update for msg " + reaction.messageId);
-                        }
-                    }
-                },
-                null,
-                null
-            );
+            ensureClient();
+            lowLevelResponses.clear();
 
 
             Client.execute(new TdApi.SetLogVerbosityLevel(5));
@@ -389,6 +339,8 @@ public void destroy(Promise promise) {
                 if (object instanceof TdApi.Ok) {
                     // TDLib accepted the request; mark local reference cleared
                     client = null;
+                    highLevelStarted = false;
+                    lowLevelResponses.clear();
                     promise.resolve("TDLib destroyed and local client reference cleared");
                 } else if (object instanceof TdApi.Error) {
                     TdApi.Error error = (TdApi.Error) object;
@@ -1681,6 +1633,70 @@ public void addComment(
 
     // =================================== Helpers ========================================
 
+    private synchronized boolean ensureClient() {
+        if (client != null) {
+            return false;
+        }
+
+        client = Client.create(
+            new Client.ResultHandler() {
+                @Override
+                public void onResult(TdApi.Object object) {
+                    emitTdLibUpdate(object);
+                }
+            },
+            null,
+            null
+        );
+        return true;
+    }
+
+    private void emitTdLibUpdate(TdApi.Object object) {
+        if (!highLevelStarted) {
+            lowLevelResponses.offer(object);
+        }
+
+        WritableMap map = Arguments.createMap();
+        String json = gson.toJson(object);
+
+        // Match iOS: TDLib-style camelCase type and raw=direct TDLib JSON.
+        String simple = object.getClass().getSimpleName();
+        String type = simple.isEmpty()
+            ? simple
+            : Character.toLowerCase(simple.charAt(0)) + simple.substring(1);
+
+        map.putString("type", type);
+        map.putString("raw", json);
+
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+            .emit("tdlib-update", map);
+
+        // Tear down the client after TDLib fully closes so the next
+        // startTdLib creates a fresh one (logout/destroy path).
+        if (object instanceof TdApi.UpdateAuthorizationState) {
+            TdApi.AuthorizationState st =
+                ((TdApi.UpdateAuthorizationState) object).authorizationState;
+            if (st instanceof TdApi.AuthorizationStateClosed) {
+                client = null;
+                highLevelStarted = false;
+                lowLevelResponses.clear();
+            }
+        }
+
+        if (object instanceof TdApi.UpdateMessageInteractionInfo) {
+            TdApi.UpdateMessageInteractionInfo interaction =
+                (TdApi.UpdateMessageInteractionInfo) object;
+            Log.d("TDLib", "Interaction update for msg " + interaction.messageId);
+        }
+
+        if (object instanceof TdApi.UpdateMessageReactions) {
+            TdApi.UpdateMessageReactions reaction =
+                (TdApi.UpdateMessageReactions) object;
+            Log.d("TDLib", "Reactions update for msg " + reaction.messageId);
+        }
+    }
+
     private void setTdLibParameters(ReadableMap parameters, Promise promise) {
         try {
             TdApi.SetTdlibParameters tdlibParameters = new TdApi.SetTdlibParameters();
@@ -1707,6 +1723,7 @@ public void addComment(
                 @Override
                 public void onResult(TdApi.Object object) {
                     if (object instanceof TdApi.Ok) {
+                        highLevelStarted = true;
                         promise.resolve("TDLib parameters set successfully");
                     } else if (object instanceof TdApi.Error) {
                         TdApi.Error error = (TdApi.Error) object;


### PR DESCRIPTION
## Summary

- fix the Android low-level TDLib bridge so `td_json_client_send` / `td_json_client_receive` can return real TDLib responses to JavaScript instead of relying on a client path that only logged updates
- keep `td_json_client_send()` fire-and-forget while the high-level `startTdLib()` event stream is active so normal app usage continues to flow through `tdlib-update` without accumulating unread low-level responses
- reject `td_json_client_receive()` once the high-level `startTdLib()` event stream is active, and reset queued low-level/high-level state on `destroy` and `authorizationStateClosed`

## Testing

- [x] `npm test -- --runInBand` passes

**For PRs that add or modify native methods (`ios/` or `android/`):**

- [ ] Ran the method in `example/` on iOS against a live TDLib session — log attached below
- [x] Ran the method in `example/` on Android against a live TDLib session — log attached below

Note: only Android code was changed in this PR (`android/src/main/java/com/reactnativetdlib/tdlibclient/TdLibModule.java`). I cannot test on an iOS device.

Additional Android verification:
- [x] `./gradlew :react-native-tdlib:compileDebugJavaWithJavac`

<details>
<summary>Device logs</summary>

```text
Android (example / MethodsTestExample)

05-10 03:20:39.810 16952 17058 I ReactNativeJS: Running "example" with {"rootTag":1}
05-10 03:20:40.008 16952 17091 I DLTD    :   deviceModel = "React Native TDLib Demo"
05-10 03:20:45.057 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ addListener (48ms): registered
05-10 03:20:45.195 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ removeListeners (0ms): ok
05-10 03:20:45.334 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ echoToJs (0ms): emitted
05-10 03:20:45.523 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ td_json_client_execute (51ms): {"@type":"textEntities","entities":[{"@type":"textEntity","length":9,"offset":0,
05-10 03:20:45.675 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getTextEntities (6ms): {"@type":"textEntities","entities":[{"@type":"textEntity","length":9,"offset":0,
05-10 03:20:45.822 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getAuthorizationState (4ms): {"@type":"authorizationStateReady"}
05-10 03:20:46.075 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getProfile (106ms): {"@type":"user","accent_color_id":0,"added_to_attachment_menu":false,"background
05-10 03:20:46.221 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getOption (3ms): 1.8.59
05-10 03:20:52.086 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ loadChats (5714ms): Chats loaded successfully
05-10 03:21:47.764 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getChats (55536ms): 20 chats
05-10 03:21:47.943 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ searchChats (24ms): []
05-10 03:21:48.424 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ searchPublicChat (329ms): {"@type":"chat","accent_color_id":4,"available_reactions":{"@type":"chatAvailabl
05-10 03:21:48.631 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getChat (49ms): {"raw":"{\"@type\":\"chat\",\"accent_color_id\":2,\"available_reactions\":{\"@ty
05-10 03:21:49.241 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ openChat (462ms): {"raw":"{\"@type\":\"chat\",\"accent_color_id\":2,\"available_reactions\":{\"@ty
05-10 03:21:49.441 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getChatHistory (55ms): 1 messages
05-10 03:21:49.598 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ viewMessages (5ms): {"@type":"ok"}
05-10 03:21:50.099 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getMessage (313ms): {"raw":"{\"@type\":\"message\",\"author_signature\":\"\",\"auto_delete_in\":0.0,
05-10 03:21:50.259 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getMessagesCompat (6ms): {"@type":"messages","messages":[{"@type":"message","author_signature":"","auto_d
05-10 03:21:50.579 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getChatMessagePosition (132ms): {"count":1,"raw":"{\"@type\":\"count\",\"count\":1}"}
05-10 03:21:50.734 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getMessageThread (5ms): {"raw":"{\"@type\":\"error\",\"code\":400,\"message\":\"Chat is not a supergroup
05-10 03:21:50.893 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getMessageThreadHistory (4ms): {"raw":"{\"@type\":\"error\",\"code\":400,\"message\":\"Can\'t get message thread
05-10 03:21:51.200 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getAddedReactions (124ms): {"raw":"{\"@type\":\"error\",\"code\":400,\"message\":\"MSG_ID_INVALID\"}"}
05-10 03:21:51.361 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ closeChat (4ms): {"success":true}
05-10 03:21:51.518 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getChatMember (6ms): {"raw":"{\"@type\":\"chatMember\",\"inviter_user_id\":493383954,\"joined_chat_da
05-10 03:21:51.745 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getUserProfile (6ms): {"@type":"user","accent_color_id":0,"added_to_attachment_menu":false,"background
05-10 03:21:51.908 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getUserFull (7ms): {"@type":"user","accent_color_id":0,"added_to_attachment_menu":false,"background
05-10 03:21:52.243 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getUserProfilePhotos (147ms): {"@type":"chatPhotos","photos":[],"total_count":0}
05-10 03:21:52.411 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getUsersCompat (7ms): [{"@type":"user","accent_color_id":0,"added_to_attachment_menu":false,"backgroun
05-10 03:21:52.581 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ createPrivateChat (14ms): {"@type":"chat","accent_color_id":0,"available_reactions":{"@type":"chatAvailabl
05-10 03:21:52.750 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ getFile (7ms): {"raw":"{\"@type\":\"file\",\"expected_size\":6904,\"id\":1,\"local\":{\"@type\"
05-10 03:21:52.911 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ downloadFile (6ms): {"raw":"{\"@type\":\"file\",\"expected_size\":6904,\"id\":1,\"local\":{\"@type\"
05-10 03:21:53.083 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ downloadFileByRemoteId (7ms): {"err":"Could not resolve file by remote id"}
05-10 03:21:53.249 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ cancelDownloadFile (6ms): {"raw":"{\"@type\":\"ok\"}"}
05-10 03:21:53.426 16952 17058 I ReactNativeJS: [MethodsTestExample] ✓ cancelDownloadByRemoteId (10ms): {"raw":"{\"@type\":\"error\",\"code\":400,\"message\":\"Wrong remote file identi
05-10 03:21:53.481 16952 17058 I ReactNativeJS: [MethodsTestExample] — Safe sweep done —
```

</details>

## Disclosure

- [x] This PR was written with meaningful AI agent assistance (see AGENTS.md)